### PR TITLE
Rewrite - support for sass & less.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
-const { parse } = require('scss-parser')
+const { parse } = require('scss-parser') // https://github.com/salesforce-ux/scss-parser
 const { readFileSync } = require('fs')
 const globAll = require('glob-all')
+
 const shouldParse = ['rule', 'selector', 'block']
 const shouldKeep = ['id', 'class', 'attribute']
 const exts = ['css', 'sass', 'scss', 'less']

--- a/index.js
+++ b/index.js
@@ -1,109 +1,90 @@
-const listSelectors = require('list-css-selectors');
-const sanitizeArgs = require('list-css-selectors/sanitizeArgs');
-const flattenArray = require('list-css-selectors/flattenArray');
-const cssWhat = require('css-what');
-const attrs = ['equals', 'start', 'end', 'element', 'hyphen', 'any', 'not'];
+const { parse } = require('scss-parser')
+const { readFileSync } = require('fs')
+const globAll = require('glob-all')
+const shouldParse = ['rule', 'selector', 'block']
+const shouldKeep = ['id', 'class', 'attribute']
+const exts = ['css', 'sass', 'scss', 'less']
 
+function makeWhitelist(filenames) {
+  filenames = sanitizeArgs(filenames)
+  if (!filenames.length) return []
 
-/*
-  This function parses css file(s) for their selectors,
-  and massages those selectors into plain text words
-  so that Purgecss can successfully whitelist them.
+  // Create a deep array, each level containing a list of selectors.
+  const deepArray = filenames.reduce((acc, filename) => {
+    // Do nothing for non-style files.
+    const ext = filename.split('.').pop()
+    if (!exts.includes(ext)) return acc
 
-  Examples
-  --------
-  .some-class         => some-class
-  #some-id            => some-id
-  [an-attribute]      => an-attribute
-  [data-test='hello'] => data-test, hello
+    const fileContents = readFileSync(filename, 'utf-8')
+    const parsedData = parse(fileContents).value
+    const selectors = parseStyleAST(parsedData)
+    return acc.concat(selectors)
+  }, [])
 
-  Arguments:
-    * `filenames` - An array of strings representing file names
-    * `list` - For testing purposes only, not officially part
-               of the API. You can manually pass a list of selectors
-               and avoid having `makeWhitelist` read file data.
-*/
-function makeWhitelist(filenames, list) {
-  filenames = !list && sanitizeArgs(filenames);
-  if (!filenames.length && !list) return [];
+  // Flatten the array.
+  const flattenedArray = flattenArray(deepArray)
 
-  const selectorErrors = [];
-  const selectors = list || listSelectors(filenames);
-  const whitelist = selectors.map(selector => {
-    let what = [];
+  // Return an array of unique selectors in alphabetical order.
+  return [...new Set(flattenedArray)].sort()
+}
 
-    try {
-      what = cssWhat(selector);
-    } catch(e) {
-      selectorErrors.push({ selector, e });
-    }
+function sanitizeArgs(arr) {
+  if (!Array.isArray(arr)) arr = [arr]
+  arr = arr.filter(Boolean)
 
-    return what.map(arr => extractNames(arr));
-  });
-
-  if (selectorErrors.length) {
-    console.log(`\n\nErrors with the following selectors (${selectorErrors.length}):`);
-    console.log('----------------------------------------');
-
-    selectorErrors.forEach(({ selector, e }) => {
-      console.log('Selector:', selector);
-      console.log('Associated error:');
-      console.log(e);
-      console.log('');
-      console.log('*** *** *** *** ***');
-      console.log('');
-    });
+  // Avoids errors if an empty array, no arguments, or falsey things are passed.
+  if (!arr.length) {
+    console.log('\n\nNo items for processing. Moving right along...\n\n')
+    return []
   }
 
-  const flatWhitelist = flattenArray(whitelist);
-  return Array.from(new Set(flatWhitelist)); // Remove duplicates.
+  // Each thing in the array must be a string.
+  if (arr.some(s => typeof s !== 'string')) throw `Oops! Something passed wasn't a string.`
+
+  // Ensure absolute paths for filenames, especially if globs were passed.
+  arr = globAll.sync(arr, { absolute: true })
+
+  // If, at the end of it all, we have nothing, leave empty-handed.
+  if (!arr.length) {
+    console.log('\n\nNo matching files found.\n\n')
+    return []
+  }
+
+  return arr
 }
 
-/*
-  Iterates through an array from the results of `cssWhat`
-  and returns names without selector characters such as [., #, >], etc.
+function parseStyleAST(arr) {
+  return arr.reduce((acc, { type, value }) => {
 
-  https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
-  List of psuedo selectors that can contain other selectors:
-    * host
-    * host-context
-    * not
-*/
-function extractNames(arr) {
-  const newArray = arr.map(({ type, name, value, action, data }) => {
-    if (type === 'attribute') {
-      // #id
-      if (name === 'id') return value;
+    // Trigger recursion for types that need it.
+    if (shouldParse.includes(type)) {
+      return acc.concat(parseStyleAST(value))
 
-      // .class
-      if (name === 'class') return value;
+    // Iterate through a type's values to extract selectors.
+    } else if (shouldKeep.includes(type)) {
+      return value
+        .reduce((acc, { type, value }) => {
+          return (type === 'identifier' && !!value) ?  acc.concat(value) : acc
+        }, acc)
 
-      // [attr]
-      if (action === 'exists') return name;
+    // Concatenate a type's value if no iteration is needed.
+    } else if (type === 'identifier' && !!value) {
+      return acc.concat(value)
 
-      /*
-        Example        Action
-        -----------------------
-        [attr=val]  | 'equals'
-        [attr^=val] | 'start'
-        [attr$=val] | 'end'
-        [attr~=val] | 'element'
-        [attr|=val] | 'hyphen'
-        [attr*=val] | 'any'
-        [attr!=val] | 'not'
-      */
-      if (attrs.includes(action)) return [name, value];
+    // No matches - acc is unchanged.
+    // This allows us to skip filtering out falsy's later.
+    } else {
+      return acc
     }
-
-    // tag
-    if (type === 'tag') return name;
-
-    // Pseudo stuffs - recursion!
-    // Type might be 'pseudo' or 'pseudo-element'.
-    if (type.includes('pseudo') && Array.isArray(data)) return data.map(arr => extractNames(arr));
-  });
-
-  return flattenArray(newArray).filter(Boolean);
+  }, [])
 }
 
-module.exports = makeWhitelist;
+function flattenArray(arr) {
+  if (!Array.isArray(arr)) return arr
+
+  return arr.reduce((acc, thing) => {
+    return Array.isArray(thing) ? acc.concat(flattenArray(thing)) : acc.concat(thing)
+  }, [])
+}
+
+module.exports = makeWhitelist

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,21 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "invariant": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
     "list-css-selectors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/list-css-selectors/-/list-css-selectors-1.3.0.tgz",
@@ -108,6 +123,21 @@
       "requires": {
         "glob": "^7.1.2",
         "postcss": "^6.0.14"
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0"
       }
     },
     "minimatch": {
@@ -139,6 +169,15 @@
         "chalk": "^2.4.1",
         "source-map": "^0.6.1",
         "supports-color": "^5.4.0"
+      }
+    },
+    "scss-parser": {
+      "version": "github:salesforce-ux/scss-parser#3c8ad4ecf007fdb0e322fe1aac2813301788678f",
+      "from": "github:salesforce-ux/scss-parser",
+      "dev": true,
+      "requires": {
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
       }
     },
     "source-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,11 +23,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "css-what": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,14 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "requires": {
-        "color-convert": "^1.9.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -26,29 +18,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
-    },
-    "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "requires": {
-        "color-name": "^1.1.1"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -58,11 +27,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
       "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -82,10 +46,14 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    "glob-all": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz",
+      "integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
+      "requires": {
+        "glob": "^7.0.5",
+        "yargs": "~1.2.6"
+      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -102,10 +70,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
+      "integrity": "sha1-sJcBBUdmjH4zcCjr6Bbr42yKjVQ=",
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -113,29 +80,17 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
-    },
-    "list-css-selectors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/list-css-selectors/-/list-css-selectors-1.3.0.tgz",
-      "integrity": "sha512-ePmPHptq2FI/iTRTo0UUeFBVqGlwjRurIfUXjnNLQ/zhTxOvtM+8TIAicvR6LEDOSg2V/pJadLeTfS8xqY/DZw==",
-      "requires": {
-        "glob": "^7.1.2",
-        "postcss": "^6.0.14"
-      }
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.1.tgz",
+      "integrity": "sha1-oyEG644uyOgsJBYRQUdzyd8V+Lw="
     },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0"
       }
@@ -147,6 +102,11 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
+      "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
     },
     "once": {
       "version": "1.4.0",
@@ -161,42 +121,27 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
-    "postcss": {
-      "version": "6.0.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-      "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-      "requires": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
-      }
-    },
     "scss-parser": {
-      "version": "github:salesforce-ux/scss-parser#3c8ad4ecf007fdb0e322fe1aac2813301788678f",
-      "from": "github:salesforce-ux/scss-parser",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/scss-parser/-/scss-parser-1.0.0.tgz",
+      "integrity": "sha1-HVCpjJr8d9z5MI6FH1wMVpNIeGg=",
       "requires": {
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      }
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-      "requires": {
-        "has-flag": "^3.0.0"
+        "invariant": "2.2.1",
+        "lodash": "4.11.1"
       }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yargs": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
+      "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
+      "requires": {
+        "minimist": "^0.1.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "purgecss-whitelister",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "author": "Qodesmith",
   "license": "MIT",
   "dependencies": {
-    "css-what": "^2.1.0",
     "glob-all": "^3.1.0",
     "scss-parser": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "css-what": "^2.1.0",
-    "list-css-selectors": "^1.3.0"
-  },
-  "devDependencies": {
-    "scss-parser": "github:salesforce-ux/scss-parser"
+    "glob-all": "^3.1.0",
+    "scss-parser": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "dependencies": {
     "css-what": "^2.1.0",
     "list-css-selectors": "^1.3.0"
+  },
+  "devDependencies": {
+    "scss-parser": "github:salesforce-ux/scss-parser"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purgecss-whitelister",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "A utility for creating whitelists of CSS selectors for use with Purgecss.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is a complete rewrite. We're now relying on [scss-parser](https://www.npmjs.com/package/scss-parser) ([github repo](https://github.com/salesforce-ux/scss-parser)) to parse the files. This supports css, sass, and less.

This package has been decoupled from [list-css-selectors](https://www.npmjs.com/package/list-css-selectors).